### PR TITLE
Assemble IL in Embedded Resources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ indent_style = space
 indent_size = 4
 end_of_line = crlf
 trim_trailing_whitespace = true
+file_header_template = Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.
 
 [{*.cs, *.vb}]
 dotnet_diagnostic.CA1707.severity = none
@@ -25,3 +26,6 @@ dotnet_diagnostic.CA1822.severity = none
 dotnet_diagnostic.CA1016.severity = none
 dotnet_diagnostic.CA1031.severity = none
 dotnet_diagnostic.CA1711.severity = none
+
+[{*.csproj, *.vcxproj, *.xml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,16 @@ indent_style = space
 indent_size = 4
 end_of_line = crlf
 trim_trailing_whitespace = true
+
+[{*.cs, *.vb}]
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1852.severity = none
+dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.CA1805.severity = none
+dotnet_diagnostic.CA1502.severity = none
+dotnet_diagnostic.CA1813.severity = none
+dotnet_diagnostic.CA5392.severity = none
+dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1016.severity = none
+dotnet_diagnostic.CA1031.severity = none
+dotnet_diagnostic.CA1711.severity = none

--- a/.github/linters/check_links_config.json
+++ b/.github/linters/check_links_config.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
         {
-          "pattern": "^https://www.microsoft\\.com.*"
+          "pattern": "^https://www\\.microsoft\\.com.*"
         }
       ],
     "aliveStatusCodes": [200, 203]

--- a/.github/linters/check_links_config.json
+++ b/.github/linters/check_links_config.json
@@ -1,3 +1,3 @@
 {
-    "aliveStatusCodes": [200, 203]
+    "aliveStatusCodes": [200, 203, 302]
 }

--- a/.github/linters/check_links_config.json
+++ b/.github/linters/check_links_config.json
@@ -1,3 +1,8 @@
 {
-    "aliveStatusCodes": [200, 203, 302]
+    "ignorePatterns": [
+        {
+          "pattern": "^http://www.microsoft.com"
+        }
+      ],
+    "aliveStatusCodes": [200, 203]
 }

--- a/.github/linters/check_links_config.json
+++ b/.github/linters/check_links_config.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
         {
-          "pattern": "^http://www.microsoft.com"
+          "pattern": "^https://www.microsoft\\.com.*"
         }
       ],
     "aliveStatusCodes": [200, 203]

--- a/InstrumentationEngine.sln
+++ b/InstrumentationEngine.sln
@@ -20,6 +20,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InstrumentationEngine.Lib.T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0574D1C6-A8BE-436A-A25F-7954F6515CDA}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		CHANGELOG.md = CHANGELOG.md
 	EndProjectSection
 EndProject
@@ -84,12 +85,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteUnitTestExecutor.Host", "src\Tests\RemoteUnitTestExecutor.Host\RemoteUnitTestExecutor.Host.csproj", "{F356AF58-F432-415D-BE13-44228F265CEF}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Common.Headers\Common.Headers.vcxitems*{0d4a6caa-80d9-4e41-859f-c14205fd45c4}*SharedItemsImports = 9
-		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
-		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{e4d25b2c-e362-4660-a2fd-ada2b7c1fd77}*SharedItemsImports = 5
-		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{ead25b2c-e362-4660-a2fd-ad82b7c1fd77}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CodeAnalysis.Managed|Any CPU = CodeAnalysis.Managed|Any CPU
 		CodeAnalysis.Managed|ARM64 = CodeAnalysis.Managed|ARM64
@@ -783,5 +778,11 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {16628EC2-6C46-4DEF-B260-8848FC916254}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Common.Headers\Common.Headers.vcxitems*{0d4a6caa-80d9-4e41-859f-c14205fd45c4}*SharedItemsImports = 9
+		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
+		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{e4d25b2c-e362-4660-a2fd-ada2b7c1fd77}*SharedItemsImports = 5
+		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{ead25b2c-e362-4660-a2fd-ad82b7c1fd77}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,12 @@
 <configuration>
     <packageSources>
         <clear />
+        <!-- Multiple package sources are required because the dotnet build tools need to be able to download SDKs from NuGet -->
         <add key="DNCENG-CoreClrPal" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/CoreClrPal/nuget/v3/index.json" />
+        <add key="dotnet31" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
+        <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+        <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+        <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.

--- a/build/Managed.props
+++ b/build/Managed.props
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <DefineConstants Condition="'$(PublicRelease)' != 'True'">$(DefineConstants);ALLOWNOTSIGNED</DefineConstants>
-    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DEBUG</DefineConstants>
     <EnableNetAnalyzers>true</EnableNetAnalyzers>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis\Sdl.Recommended.Error.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,5 +18,6 @@ Merge Module
 
 |Version|Installer (.msi)|Merge Module (.msm)|
 |-|-|-|
-|1.0.42 (latest)|[ [x64](https://aka.ms/clrie/1.0.42/x64/msi) \| [x86](https://aka.ms/clrie/1.0.42/x86/msi) ]|[ [x64](https://aka.ms/clrie/1.0.42/x64/msm) \| [x86](https://aka.ms/clrie/1.0.42/x86/msm) ]|
+|1.0.45 (latest)|[ [x64](https://aka.ms/clrie/release/1.0.45/x64/msi) \| [x86](https://aka.ms/clrie/release/1.0.45/x86/msi) ]|[ [x64](https://aka.ms/clrie/release/1.0.45/x64/msm) \| [x86](https://aka.ms/clrie/release/1.0.45/x86/msm) ]|
+|1.0.42|[ [x64](https://aka.ms/clrie/1.0.42/x64/msi) \| [x86](https://aka.ms/clrie/1.0.42/x86/msi) ]|[ [x64](https://aka.ms/clrie/1.0.42/x64/msm) \| [x86](https://aka.ms/clrie/1.0.42/x86/msm) ]|
 |1.0.31|[ [x64](https://aka.ms/clrie/1.0.31/x64/msi) \| [x86](https://aka.ms/clrie/1.0.31/x86/msi) ]|[ [x64](https://aka.ms/clrie/1.0.31/x64/msm) \| [x86](https://aka.ms/clrie/1.0.31/x86/msm) ]|

--- a/src/Extensions.Base.Api.Tests/ExtensionsBaseCallbacks.cs
+++ b/src/Extensions.Base.Api.Tests/ExtensionsBaseCallbacks.cs
@@ -19,6 +19,8 @@ namespace ProfilerCallbacksTests
 
         private readonly object thisObj = new object();
         private readonly object returnValue = new object();
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "This is specifically used for test code.")]
         private readonly Exception exception = new Exception();
 
         private CallbackStubIsCalled callbacksStub;

--- a/src/Extensions.Base.Api/PublicContract.cs
+++ b/src/Extensions.Base.Api/PublicContract.cs
@@ -344,6 +344,7 @@ namespace _System.Diagnostics
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1502:Method has cyclomatic complexity of '29'", Justification = "This function is not changed often, and should not be updated.")]
         public static void ApplicationInsights_RemoveCallbacks(int methodId, int argsCount)
         {
             switch (argsCount)

--- a/src/InstrumentationEngine.Attach/NativeMethods.cs
+++ b/src/InstrumentationEngine.Attach/NativeMethods.cs
@@ -10,6 +10,7 @@ namespace Microsoft.InstrumentationEngine
     {
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes", Justification = "Function exists in kernel32.dll, which has special loading logic controlled by the kernel.")]
         public static extern bool IsWow64Process([In] IntPtr hProcess, [Out] out bool wow64Process);
     }
 }

--- a/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResourceUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResourceUtils.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstrEngineTests
+{
+
+    /// <summary>
+    /// A temporary file that was extracted from an embedded resource. The file will
+    /// be placed in a folder under the test's profile directory.
+    /// </summary>
+    internal interface IEmbeddedResourceFile
+    {
+        /// <summary>
+        /// Path to the extracted file.
+        /// </summary>
+        string FilePath { get; }
+
+        /// <summary>
+        /// The original name of the resource.
+        /// </summary>
+
+        string ResourceName { get; }
+    }
+
+    internal class EmbeddedResourceUtils
+    {
+
+        private const string EmbeddedResourcesPath = "InstrEngineTests.EmbeddedResources";
+        private static readonly object ExtractionLock = new object();
+
+        /// <inheritdoc/>
+        internal class EmbeddedResourceFile : IEmbeddedResourceFile
+        {
+            private FileInfo _tempFile;
+
+            /// <inheritdoc/> 
+            public string FilePath => _tempFile.FullName;
+
+            /// <inheritdoc/>
+            public string ResourceName { get; }
+
+            public EmbeddedResourceFile(FileInfo tempFile, string resourceName)
+            {
+                _tempFile = tempFile;
+                ResourceName = resourceName;
+            }
+
+            internal void CopyFromStream(Stream stream)
+            {
+                using (var writeStream = _tempFile.Open(FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                {
+                    stream.CopyTo(writeStream);
+                }
+            }
+        }
+
+        public static string ReadEmbeddedResourceFile(string file, bool required = true)
+        {
+            Stream stream = GetEmbeddedResource(file, required);
+            if (stream == null)
+            {
+                return null;
+            }
+
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        /// <summary>
+        /// Looks for the given embedded resource, and extracts it to the test assets folder.
+        /// If the file was previously extracted, it is not overwritten.
+        /// </summary>
+        /// <param name="resourceName">The name of the resource.</param>
+        /// <param name="required">True if an error should occur when the resource is not found.</param>
+        /// <returns>An IEmbeddedResourceFile that has info about the extracted file.</returns>
+        public static IEmbeddedResourceFile GetTestResourceFile(string resourceName, bool required = true)
+        {
+            // Don't allow parallel tests to overwrite extracted files.
+            lock (ExtractionLock)
+            {
+                Stream stream = GetEmbeddedResource(resourceName, required);
+                if (stream == null)
+                {
+                    return null;
+                }
+                using (stream)
+                {
+                    DirectoryInfo resourceDirectory = new DirectoryInfo(PathUtils.GetResourcesFolder());
+                    resourceDirectory.Create();
+
+                    string tempFileName = Path.Combine(PathUtils.GetResourcesFolder(), resourceName);
+                    FileInfo fileInfo = new FileInfo(tempFileName);
+                    var embeddedResource = new EmbeddedResourceFile(fileInfo, resourceName);
+                    try
+                    {
+                        if (!fileInfo.Exists)
+                        {
+                            embeddedResource.CopyFromStream(stream);
+                        }
+
+                        return embeddedResource;
+                    }
+                    catch (Exception e)
+                    {
+                        Assert.Fail(e.Message);
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Deletes all test resource files that have been previously extracted.
+        /// </summary>
+        public static void CleanTestResourceFiles()
+        {
+            lock (ExtractionLock)
+            {
+                DirectoryInfo resourceDirectory = new DirectoryInfo(PathUtils.GetResourcesFolder());
+                if (resourceDirectory.Exists)
+                {
+                    foreach (FileInfo f in resourceDirectory.EnumerateFiles())
+                    {
+                        f.Delete();
+                    }
+                }
+            }
+        }
+
+        private static Stream GetEmbeddedResource(string fileName, bool required = true)
+        {
+            Assert.IsNotNull(fileName);
+
+            var fullPath = FormattableString.Invariant($"{EmbeddedResourcesPath}.{fileName}");
+
+            var stream = typeof(EmbeddedResourceUtils).Assembly.GetManifestResourceStream(fullPath);
+
+            if (required)
+            {
+                Assert.IsNotNull(stream, "Could not find embedded resource {0}", fullPath);
+            }
+
+            return stream;
+        }
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/ByRefLikeInvalidCSharp.il
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/ByRefLikeInvalidCSharp.il
@@ -1,0 +1,631 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+
+.assembly InvalidCSharp { }
+
+//
+// Begin invalid
+//
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_Invalid`1<T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}
+
+.class interface public auto ansi abstract InvalidCSharp.GenericInterface_Invalid`1<T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueType_Invalid`1<T>
+    extends [System.Runtime]System.ValueType
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericByRefLike_Invalid`1<T>
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+}
+
+//
+// End invalid
+//
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_Over`1<byreflike T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}
+
+.class interface public auto ansi abstract InvalidCSharp.GenericInterface_Over`1<byreflike T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueType_Over`1<byreflike T>
+    extends [System.Runtime]System.ValueType
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericByRefLike_Over`1<byreflike T>
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+
+    .field public !T Field
+
+    .method public hidebysig
+        instance object BoxAsObject(!T) cil managed
+    {
+        ldarg.1
+        box !T
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxUnboxAny(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            unbox.any !T
+        // End sequence
+        pop
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxBranch(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxBranch_WithSideEffects(!T&) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxIsinstUnboxAny(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            unbox.any !T
+        // End sequence
+        pop
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxIsinstBranch(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxIsinstBranch_WithSideEffects(!T&) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool AllocArrayOfT() cil managed aggressiveinlining
+    {
+        ldc.i4.1
+        newarr !T
+        ldnull
+        cgt.un
+        ret
+    }
+
+    .method public hidebysig
+        instance bool AllocMultiDimArrayOfT() cil managed
+    {
+        ldc.i4.1
+        ldc.i4.1
+        newobj instance void !T[0..., 0...]::.ctor(int32, int32)
+        ldnull
+        cgt.un
+        ret
+    }
+
+    .method public hidebysig
+        instance bool InstanceOfT(
+            object o
+        ) cil managed
+    {
+        ldarg.1
+        isinst !T
+        ldnull
+        cgt.un
+        ret
+    }
+
+    .method public hidebysig
+        instance void CastToT(
+            object o
+        ) cil managed
+    {
+        ldarg.1
+        castclass !T
+        pop
+        ret
+    }
+
+    .method public hidebysig
+        instance void UnboxToT(
+            object o
+        ) cil managed
+    {
+        ldarg.1
+        unbox.any !T
+        pop
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_WithStaticField`1<byreflike T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .locals init (
+            [0] !T,
+            [1] !T
+        )
+
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+
+        ldloca.s 0
+        initobj !T
+
+        ldloc.0
+        stsfld !0 class InvalidCSharp.GenericClass_WithStaticField`1<!T>::StaticField
+        ldsfld !0 class InvalidCSharp.GenericClass_WithStaticField`1<!T>::StaticField
+        stloc.1
+        ret
+    }
+
+    .field public static !T StaticField
+}
+
+.class public sequential ansi sealed beforefieldinit ByRefLikeType
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+}
+
+.class public auto ansi abstract sealed beforefieldinit Exec
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig static
+        string GenericClass() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericInterface() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericInterface_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericValueType() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueType_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericByRefLike() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string GenericClass_Invalid() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericInterface_Invalid() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericInterface_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericValueType_Invalid() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueType_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericByRefLike_Invalid() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericByRefLike_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        object BoxAsObject() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance object valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxAsObject(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxUnboxAny() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxUnboxAny(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxBranch() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>,
+            [1] bool
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxBranch(!0)
+        pop
+
+        ldloca.s 0
+        ldloca.s 0
+        ldflda !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxBranch_WithSideEffects(!0&)
+
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxIsinstUnboxAny() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstUnboxAny(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxIsinstBranch() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstBranch(!0)
+        pop
+
+        ldloca.s 0
+        ldloca.s 0
+        ldflda !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstBranch_WithSideEffects(!0&)
+
+        ret
+    }
+
+    .method public hidebysig static
+        void AllocArrayOfT_Invalid() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::AllocArrayOfT()
+        pop
+        ret
+    }
+
+    .method public hidebysig static
+        void AllocMultiDimArrayOfT_Invalid() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::AllocMultiDimArrayOfT()
+        pop
+        ret
+    }
+
+    .method public hidebysig static
+        string GenericClassWithStaticField_Invalid() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_WithStaticField`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        bool InstanceOfT(object) cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldarg.0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::InstanceOfT(object)
+        ret
+    }
+
+    .method public hidebysig static
+        void CastToT(object) cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldarg.0
+        call instance void valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::CastToT(object)
+        ret
+    }
+
+    .method public hidebysig static
+        void UnboxToT(object) cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldarg.0
+        call instance void valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::UnboxToT(object)
+        ret
+    }
+
+    .method public hidebysig static
+        bool TypeLoadExceptionAvoidsInline(bool) cil managed noinlining
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldarg.0
+        brfalse.s DONTCALL
+
+        ldloca.s 0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::AllocArrayOfT()
+        br.s DONE
+
+        // Negate the input and return
+        DONTCALL: ldarg.0
+        ldc.i4.0
+        ceq
+
+        DONE: ret
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/RefFieldInvalidCSharp.il
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/RefFieldInvalidCSharp.il
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+
+.assembly InvalidCSharp { }
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithRefField
+    extends [System.Runtime]System.ValueType
+{
+    // Type requires IsByRefLikeAttribute to be valid.
+    .field public string& Invalid
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidRefFieldAlignment
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public int16 Field
+    .field [2] public int32& Invalid
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidObjectRefRefFieldOverlap
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public object Field
+    .field [0] public int32& Invalid
+}
+
+// This is invalid metadata and is unable to be loaded.
+// -  [field sig] (0x80131815 (VER_E_FIELD_SIG))
+//
+// .class public sequential ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithStaticRefField
+//     extends [System.Runtime]System.ValueType
+// {
+//     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+//         01 00 00 00
+//     )
+//     .field public static string& Invalid
+// }
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.IntPtrRefFieldOverlap
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public native int Field
+    .field [0] public int32& Invalid
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.InnerValidByRef
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public int32& Field
+    .field public int32 Size
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.IntPtrOverlapWithInnerFieldType
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public native int Field
+    // This field's valid Type would illegally overlap this type's first field using a precise GC.
+    .field [0] public valuetype InvalidCSharp.InnerValidByRef Invalid
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefField
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public string& Str
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            string&
+        ) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        stfld string& InvalidCSharp.WithRefField::Str
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            string
+        ) cil managed
+    {
+        ldarg.0
+        ldfld string& InvalidCSharp.WithRefField::Str
+        ldind.ref
+        ldarg.1
+        ceq
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefStructField
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public valuetype InvalidCSharp.WithRefField& Field
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            valuetype InvalidCSharp.WithRefField&
+        ) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        stfld valuetype InvalidCSharp.WithRefField& InvalidCSharp.WithRefStructField::Field
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            valuetype InvalidCSharp.WithRefField&
+        ) cil managed
+    {
+        ldarg.0
+        ldfld valuetype InvalidCSharp.WithRefField& InvalidCSharp.WithRefStructField::Field
+        ldind.ref
+        ldarg.1
+        ldind.ref
+        ceq
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithTypedReferenceField`1<T>
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public typedref Field
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            !T&
+        ) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        mkrefany !T
+        stfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        ret
+    }
+
+    .method public hidebysig
+        instance class [System.Runtime]System.Type GetFieldType () cil managed
+    {
+        ldarg.0
+        ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        refanytype
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle )
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            !T
+        ) cil managed
+    {
+        ldarg.0
+        ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        refanyval !T
+        ldind.ref
+        ldarg.1
+        ceq
+        ret
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
@@ -11,6 +11,10 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>InstrEngineTests</RootNamespace>
   </PropertyGroup>
+  <PropertyGroup>
+    <NetCoreVersion>7.0.0-preview.4.22229.4</NetCoreVersion>
+    <IlAsmLocation>$(NuGetPackageRoot)\microsoft.netcore.ilasm\$(NetCoreVersion)\runtimes\native\ilasm.exe</IlAsmLocation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="EmbeddedResources\**" />
     <EmbeddedResource Include="EmbeddedResources\**" />
@@ -21,6 +25,9 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.IL" Version="$(NetCoreVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(NetCoreVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(NetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Baselines\AddBranchTargets_ArrayForeachTest.xml">
@@ -493,6 +500,11 @@
       <Link>TestScripts\MultiReturn_SwitchTest.xml</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup Condition="Exists('$(ILAsmLocation)')">
+    <EmbeddedResource Include="$(ILAsmLocation)">
+      <Link>EmbeddedResources\ilasm.exe</Link>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
 </Project>

--- a/src/Tests/InstrEngineTests/InstrEngineTests/NativeMethods.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/NativeMethods.cs
@@ -9,10 +9,15 @@ namespace InstrEngineTests
 {
     internal class NativeMethods
     {
+
+        // Disable warning because kernel32.dll has special loading logic in the kernel
+#pragma warning disable CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
         [DllImport("kernel32.dll")]
         public static extern int GetComPlusPackageInstallStatus();
 
         [DllImport("kernel32.dll")]
         public static extern bool SetComPlusPackageInstallStatus(int flag);
+
+#pragma warning restore CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
     }
 }

--- a/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
@@ -11,6 +11,7 @@ namespace InstrEngineTests
         private const string BaselinesFolder = "Baselines";
         private const string TestResultsFolder = "TestResults";
         private const string TestScriptsFolder = "TestScripts";
+        private const string ResourcesFolder = "ExtractedResources";
 
         // All paths are relative to the AnyCPU binaries directory e.g. bin\Debug\AnyCPU
         public const string BaselinesBinPath = @".\" + BaselinesFolder;
@@ -25,6 +26,11 @@ namespace InstrEngineTests
         public static string GetAssetsPath()
         {
             return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+        public static string GetResourcesFolder()
+        {
+            return Path.Combine(GetAssetsPath(), ResourcesFolder);
         }
 
         public static string GetBaselinesPath()

--- a/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -76,8 +76,9 @@ namespace InstrEngineTests
             if (!BinaryRecompiled)
             {
                 BinaryRecompiled = true;
+                EmbeddedResourceUtils.CleanTestResourceFiles();
                 TargetAppCompiler.DeleteExistingBinary(PathUtils.GetAssetsPath());
-                TargetAppCompiler.ComplileCSharpTestCode(PathUtils.GetAssetsPath());
+                TargetAppCompiler.CompileTestCode(PathUtils.GetAssetsPath());
             }
 
             DeleteOutputFileIfExist(output);

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestAppAssembler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestAppAssembler.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstrEngineTests
+{
+    internal class TestAppAssembler
+    {
+        internal static bool AssembleFile(IEmbeddedResourceFile embeddedResource, string directoryPath, string assemblyName, bool isDebug, bool is64Bit, bool isExe = false)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+            IEmbeddedResourceFile ilasm = EmbeddedResourceUtils.GetTestResourceFile("ilasm.exe");
+            if (ilasm == null)
+            {
+                return false;
+            }
+
+            psi.FileName = ilasm.FilePath;
+            psi.RedirectStandardError = true;
+            psi.RedirectStandardOutput = true;
+            psi.UseShellExecute = false;
+            string debugSwitch = isDebug ? "/DEBUG=OPT" : string.Empty;
+            string bitSwitch = is64Bit ? "/X64" : "/32BITPREFERRED";
+            string outputType = isExe ? "/EXE" : "/DLL";
+            string extension = isExe ? "exe" : "dll";
+            string outputFile = Path.Combine(directoryPath, FormattableString.Invariant($"{assemblyName}.{extension}"));
+            psi.Arguments = FormattableString.Invariant($"{debugSwitch} {bitSwitch} {outputType} /OUTPUT=\"{outputFile}\" \"{embeddedResource.FilePath}\"");
+            Process p = Process.Start(psi);
+            p.WaitForExit();
+            string stdOut = p.StandardOutput.ReadToEnd();
+            string stdErr = p.StandardError.ReadToEnd();
+            Assert.IsTrue(p.ExitCode == 0, FormattableString.Invariant($"Assembly failed for '{embeddedResource.FilePath}' : {stdOut} \n\n {stdErr}"));
+            return p.ExitCode == 0;
+        }
+    }
+}

--- a/src/Tests/RemoteUnitTestExecutor.Host/RemoteUnitTestExecutor.Host.csproj
+++ b/src/Tests/RemoteUnitTestExecutor.Host/RemoteUnitTestExecutor.Host.csproj
@@ -11,7 +11,7 @@
     <PropertyGroup>
         <TargetFrameworks>net462</TargetFrameworks>
         <OutputType>Exe</OutputType>
-        <AssemblyName>RemoteUnitTestExecutor.Host_x86</AssemblyName>
+        <AssemblyName>RemoteUnitTestExecutor.Host.x86</AssemblyName>
         <RootNamespace>RemoteUnitTestExecutor.Host</RootNamespace>
         <!-- Make assembly PE32 (32-bit PE header; forces .NET Framework 32-bit) -->
         <PlatformTarget>x86</PlatformTarget>

--- a/src/Tests/RemoteUnitTestExecutor/Program.cs
+++ b/src/Tests/RemoteUnitTestExecutor/Program.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+
 namespace RemoteUnitTestExecutor
 {
     using System;

--- a/src/Tests/RemoteUnitTestExecutor/TestBase.cs
+++ b/src/Tests/RemoteUnitTestExecutor/TestBase.cs
@@ -9,7 +9,7 @@ namespace RemoteUnitTestExecutor
     /// </summary>
     public abstract class TestBase : ITestBase
     {
-        public TestBase()
+        protected TestBase()
         {
             TestResult = new TestResult();
         }

--- a/tests/ApplicationInsightsCompatibility/Intercept.2.0.1.Tests/Intercept.2.0.1.Tests.csproj
+++ b/tests/ApplicationInsightsCompatibility/Intercept.2.0.1.Tests/Intercept.2.0.1.Tests.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>Intercept_2_0_1.Tests</RootNamespace>
-    <AssemblyName>Intercept.2.0.1.Tests_$(Platform)</AssemblyName>
+    <AssemblyName>Intercept.2.0.1.Tests.$(Platform)</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>

--- a/tests/ApplicationInsightsCompatibility/Intercept.Latest.Tests/Intercept.Latest.Tests.csproj
+++ b/tests/ApplicationInsightsCompatibility/Intercept.Latest.Tests/Intercept.Latest.Tests.csproj
@@ -8,16 +8,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), EnlistmentRoot.marker))\build\Managed.props" />
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <DefineConstants>$(DefineConstants);X86</DefineConstants>
-    <AssemblyName>Intercept.Latest.Tests_x86</AssemblyName>
+    <AssemblyName>Intercept.Latest.Tests.x86</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <DefineConstants>$(DefineConstants);X64</DefineConstants>
-    <AssemblyName>Intercept.Latest.Tests_x64</AssemblyName>
+    <AssemblyName>Intercept.Latest.Tests.x64</AssemblyName>
   </PropertyGroup>
   <PropertyGroup>
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>Intercept.Latest.Tests</RootNamespace>
-    <AssemblyName>Intercept.Latest.Tests_$(Platform)</AssemblyName>
+    <AssemblyName>Intercept.Latest.Tests.$(Platform)</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>

--- a/tests/RawProfilerHook/RawProfilerHook.Tests/RawProfilerHook.Tests.csproj
+++ b/tests/RawProfilerHook/RawProfilerHook.Tests/RawProfilerHook.Tests.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>RawProfilerHook.Tests</RootNamespace>
-    <AssemblyName>RawProfilerHook.Tests_$(Platform)</AssemblyName>
+    <AssemblyName>RawProfilerHook.Tests.$(Platform)</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>

--- a/tests/RawProfilerHook/RawProfilerHook/CoRawProfilerHook.cpp
+++ b/tests/RawProfilerHook/RawProfilerHook/CoRawProfilerHook.cpp
@@ -75,7 +75,7 @@ HRESULT STDMETHODCALLTYPE CCoRawProfilerHook::ModuleLoadFinished(
     WCHAR modName[MAX_PATH];
     HRESULT hr = S_OK;
 
-    const WCHAR* testModuleName = L"RawProfilerHook.Tests_x"
+    const WCHAR* testModuleName = L"RawProfilerHook.Tests.x"
 #if defined(_X86_)
         L"86"
 #else


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Assemble IL in Embedded Resources

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Example change
1) Copy ilasm as an embedded resource into the InstrEngineTests assembly
2) Add il files to embedded resources
3) Refactor the compiler helpers to extract embedded resources as files
4) Invoke ilasm to assemble the embedded il

Note: I think that ILASM is only available for Windows, so we may need to update our build steps, in the future, to run ILASM for assembly il files, and embed them into the instrumentation engine tests, or bundle them as part of the deployment.

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->

Manual testing by executing tests in Visual Studio